### PR TITLE
Update OperatorGroup and Subscriptions when exist

### DIFF
--- a/deploy/olm-catalog/common-service-operator/0.0.3/common-service-operator.v0.0.3.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/common-service-operator/0.0.3/common-service-operator.v0.0.3.clusterserviceversion.yaml
@@ -6,6 +6,35 @@ metadata:
       [
         {
           "apiVersion": "operator.ibm.com/v1alpha1",
+          "kind": "CommonServiceConfig",
+          "metadata": {
+            "name": "common-service"
+          },
+          "spec": {
+            "services": [
+              {
+                "name": "jenkins",
+                "spec": {
+                  "jenkins": {
+                    "service": {
+                      "port": 8081
+                    }
+                  }
+                }
+              },
+              {
+                "name": "etcd",
+                "spec": {
+                  "etcdCluster": {
+                    "size": 1
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "apiVersion": "operator.ibm.com/v1alpha1",
           "kind": "CommonServiceSet",
           "metadata": {
             "name": "common-service"
@@ -46,35 +75,6 @@ metadata:
                 "packageName": "etcd",
                 "sourceName": "community-operators",
                 "sourceNamespace": "openshift-marketplace"
-              }
-            ]
-          }
-        },
-        {
-          "apiVersion": "operator.ibm.com/v1alpha1",
-          "kind": "CommonServiceConfig",
-          "metadata": {
-            "name": "common-service"
-          },
-          "spec": {
-            "services": [
-              {
-                "name": "jenkins",
-                "spec": {
-                  "jenkins": {
-                    "service": {
-                      "port": 8081
-                    }
-                  }
-                }
-              },
-              {
-                "name": "etcd",
-                "spec": {
-                  "etcdCluster": {
-                    "size": 1
-                  }
-                }
               }
             ]
           }

--- a/pkg/controller/commonserviceset/commonserviceset_controller.go
+++ b/pkg/controller/commonserviceset/commonserviceset_controller.go
@@ -119,7 +119,6 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		return err
 	}
 
-
 	return nil
 }
 

--- a/pkg/controller/commonserviceset/commonserviceset_controller.go
+++ b/pkg/controller/commonserviceset/commonserviceset_controller.go
@@ -111,6 +111,15 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		return err
 	}
 
+	err = c.Watch(&source.Kind{Type: &olmv1.OperatorGroup{}}, &handler.EnqueueRequestForOwner{
+		IsController: true,
+		OwnerType:    &operatorv1alpha1.CommonServiceSet{},
+	})
+	if err != nil {
+		return err
+	}
+
+
 	return nil
 }
 


### PR DESCRIPTION
@DanielXLee 
I think we need to update the operator group and subscription when they exist to support the upgrade scenario and if users want to operator group and subscription after install.